### PR TITLE
fix "setting multiple cookies fails" bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,11 +35,11 @@ module.exports = {
 
 				var curCookies = res.header(HEADER);
 
-				if(!curCookies instanceof Array){
+				if( !(curCookies instanceof Array) ) {
 					curCookies = [curCookies];
 				}
 				
-				curCookies.push( cookies.serialize(key, val, opts) );
+				curCookies.push( cookie.serialize(key, val, opts) );
 
 				res.header(HEADER, curCookies);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restify-cookies",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Adds cookie parsing/setting to restify",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
setting multiple cookies used to fail due to 2 typos in the code

``` javascript
res.setCookie('x', '1');
res.setCookie('y', '2');
```
