### PR TITLE
fix(setCookie): calling several times Set-Cookie is now working

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,9 +3,9 @@ var cookie = require('cookie');
 module.exports = {
 	/**
 	 * Parse function to be handed to restify server.use
-	 * 
+	 *
 	 * @param  {object}   req
-	 * @param  {object}   res 
+	 * @param  {object}   res
 	 * @param  {Function} next
 	 * @return {undefined}
 	 */
@@ -22,32 +22,16 @@ module.exports = {
 		/**
 		 * Add a cookie to our response.  Uses a Set-Cookie header
 		 * per cookie added.
-		 * 
+		 *
 		 * @param {String} key  - Cookie name
 		 * @param {String} val  - Cookie value
-		 * @param {[type]} opts - Options object can contain path, secure, 
+		 * @param {[type]} opts - Options object can contain path, secure,
 		 *     expires, domain, http
 		 */
 		res.setCookie = function(key, val, opts){
 
-			var HEADER = "Set-Cookie";
-			if(res.header(HEADER)){
+			res.header("Set-Cookie", cookie.serialize(key,val, opts));
 
-				var curCookies = res.header(HEADER);
-
-				if( !(curCookies instanceof Array) ) {
-					curCookies = [curCookies];
-				}
-				
-				curCookies.push( cookie.serialize(key, val, opts) );
-
-				res.header(HEADER, curCookies);
-
-			} else {
-
-				res.header(HEADER, cookie.serialize(key,val, opts));
-
-			}
 		};
 
 		next();


### PR DESCRIPTION
Hey, 

not sure what is the goal of the first block of setCookie, but I got weird `Set-Cookie` headers when calling it several times.

***

Calling setCookie three times (foulDeviceUID, foulDeviceUID2, foulSessionUID) would result in these wrong headers

```
Set-Cookie: foulDeviceUID=device_x
Set-Cookie: foulDeviceUID=device_x,foulDeviceUID2=device_x
Set-Cookie: foulSessionUID=session_x
Set-Cookie: foulDeviceUID=device_x,foulDeviceUID=device_x,foulDeviceUID2=device_x,foulSessionUID=session_x
```
The value of `foulDeviceUID` is now `device_x,foulDeviceUID=device_x,foulDeviceUID2=device_x,foulSessionUID=session_x`

Removing the first block of setCookie yield this result: 

```
Set-Cookie: foulDeviceUID=device_x
Set-Cookie: foulDeviceUID2=device_x
Set-Cookie: foulSessionUID=session_x
```

and now works as expected.