### PR TITLE
Use setHeader

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,11 +49,11 @@ module.exports = {
 				
 				curCookies.push( cookie.serialize(key, val, opts) );
 
-				res.header(HEADER, curCookies);
+				res.setHeader(HEADER, curCookies);
 
 			} else {
 
-				res.header(HEADER, cookie.serialize(key,val, opts));
+				res.setHeader(HEADER, cookie.serialize(key,val, opts));
 
 			}
 		};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restify-cookies",
-  "version": "0.2.3",
+  "version": "0.2.4",
   "description": "Adds cookie parsing/setting to restify",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
The use of res.header when calling setCookie multiple times causes problems. Use res.setHeader instead.

```javascript
var CookieParser = require('restify-cookies');
var Restify = require('restify');

var server = Restify.createServer();

server.use(CookieParser.parse);

server.get('/', function(req, res, next){
  res.setCookie('first', '1');
  res.setCookie('second', '2');
  res.setCookie('third', '3');
  
  res.send(JSON.stringify(req.cookies));

});

server.listen(8080);
```

Current result:
```
→ curl -i http://localhost:8080/

HTTP/1.1 200 OK
Server: restify
Set-Cookie: first=1
Set-Cookie: first=1,second=2
Set-Cookie: third=3
Set-Cookie: first=1,first=1,second=2,third=3,
Content-Type: application/json
Content-Length: 4
Date: Tue, 03 Apr 2018 15:43:19 GMT
Connection: keep-alive
```

Expected result:
```
→ curl -i http://localhost:8080/

HTTP/1.1 200 OK
Server: restify
Set-Cookie: first=1
Set-Cookie: second=2
Set-Cookie: third=3
Content-Type: application/json
Content-Length: 4
Date: Tue, 03 Apr 2018 15:44:18 GMT
Connection: keep-alive
```