### PR TITLE
Don't fold multiple cookies into one header

### DIFF
--- a/index.js
+++ b/index.js
@@ -37,25 +37,8 @@ module.exports = {
 		 *     expires, domain, http
 		 */
 		res.setCookie = function setCookie (key, val, opts){
-
 			var HEADER = "Set-Cookie";
-			if(res.header(HEADER)){
-
-				var curCookies = res.header(HEADER);
-
-				if( !(curCookies instanceof Array) ) {
-					curCookies = [curCookies];
-				}
-				
-				curCookies.push( cookie.serialize(key, val, opts) );
-
-				res.header(HEADER, curCookies);
-
-			} else {
-
-				res.header(HEADER, cookie.serialize(key,val, opts));
-
-			}
+			res.header(HEADER, cookie.serialize(key, val, opts));
 		};
 
 		res.clearCookie = function clearCookie (key, opts) {


### PR DESCRIPTION
According to http://tools.ietf.org/html/rfc6265#section-3

>   Origin servers SHOULD NOT fold multiple Set-Cookie header fields into
>   a single header field.  The usual mechanism for folding HTTP headers
>   fields (i.e., as defined in [RFC2616]) might change the semantics of
>   the Set-Cookie header field because the %x2C (",") character is used
>   by Set-Cookie in a way that conflicts with such folding.

This simplifies the code and provides coherent responses when setting
mulmultiple cookies.